### PR TITLE
Lecce e Foggia - nomi scambiati

### DIFF
--- a/italia.json
+++ b/italia.json
@@ -64,7 +64,7 @@
 		{
 			"nome": "Puglia",
 			"capoluoghi": ["Bari", "Barletta-Andria-Trani", "Brindisi", "Lecce", "Foggia", "Taranto"],
-			"province":["BA","BT","BR","FG","LE","TA"]
+			"province":["BA","BT","BR","LE","FG","TA"]
 		},
 		{
 			"nome": "Sardegna",

--- a/italia_comuni.json
+++ b/italia_comuni.json
@@ -17125,7 +17125,7 @@
                         {
                             "code": "097066", 
                             "cap": "23888", 
-                            "nome": "Perego"
+                            "nome": "La Valletta Brianza"
                         }, 
                         {
                             "code": "097067", 
@@ -17156,11 +17156,6 @@
                             "code": "097072", 
                             "cap": "23849", 
                             "nome": "Rogeno"
-                        }, 
-                        {
-                            "code": "097073", 
-                            "cap": "23888", 
-                            "nome": "Rovagnate"
                         }, 
                         {
                             "code": "097074", 


### PR DESCRIPTION
Le provincie di Lecce e Foggia hanno associate i comuni corretti, ma hanno nomi sbagliati. 
Sono stati invertiti. Ovvero nella sezione delle provincie di Foggia c'è il nome "Lecce" con campo code corretto, e per le provincie di Lecce viceversa.
